### PR TITLE
Fix the inherited return type is different to the implemented return type

### DIFF
--- a/src/Gateways/LogGateway.php
+++ b/src/Gateways/LogGateway.php
@@ -12,11 +12,13 @@ use Overtrue\EasySms\Support\Config;
 
 class LogGateway extends Gateway
 {
-    public function send(PhoneNumberInterface $number, MessageInterface $message, Config $config): void
+    public function send(PhoneNumberInterface $number, MessageInterface $message, Config $config)
     {
         $channel = $this->config->get('channel');
         $level = $this->config->get('level', 'info');
 
         Log::channel($channel)->{$level}(sprintf('number: %s, message: "%s", template: "%s", data: %s, type: %s', $number, $message->getContent($this), $message->getTemplate($this), json_encode($message->getData($this)), $message->getMessageType()));
+
+        return ['success' => true, 'msg' => 'ok'];
     }
 }


### PR DESCRIPTION
The inherited return type 'array<array-key, mixed>' for `Overtrue\EasySms\Contracts\GatewayInterface::send` is different to the implemented return type for `Zing\LaravelSms\Gateways\NullGateway::send` 'null'.